### PR TITLE
E2E: Add step to wait Grafana to start before tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,12 +57,12 @@ jobs:
           compose-file: './docker-compose.yaml'
 
       - name: Wait for Grafana to start
-        run: |
-          for i in {1..30}; do
-            curl -s http://localhost:3000/login && break
-            sleep 1
-          done
-
+        uses: nev7n/wait_for_response@v1
+        with:
+          url: 'http://localhost:3000/'
+          responseCode: 200
+          timeout: 60000
+          interval: 500
       - name: Run Playwright tests
         run: yarn playwright test
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,9 +56,16 @@ jobs:
         with:
           compose-file: './docker-compose.yaml'
 
+      - name: Wait for Grafana to start
+        run: |
+          for i in {1..30}; do
+            curl -s http://localhost:3000/login && break
+            sleep 1
+          done
+
       - name: Run Playwright tests
         run: yarn playwright test
-      
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -67,4 +74,3 @@ jobs:
           retention-days: 30
 
     timeout-minutes: 60
-      


### PR DESCRIPTION
The new environment introduced by create plugin tools take way more time to run, therefore we have to explicitly wait for Grafana to be up before starting the tests.