### PR TITLE
Add downstream error to NewDatasource

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -34,6 +34,7 @@
     "surql",
     "surrealdb",
     "typecheck",
-    "vals"
+    "vals", 
+    "errorsource"
   ]
 }

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana-labs/surrealdb-datasource/pkg/client"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/slo"
 	"github.com/surrealdb/surrealdb.go"
 )
@@ -46,14 +47,14 @@ func NewDatasource(ctx context.Context, dsiConfig backend.DataSourceInstanceSett
 
 	db, err := surrealdb.New(config.Endpoint)
 	if err != nil {
-		return nil, err
+		return nil, errorsource.DownstreamError(err, false)
 	}
 
 	client := client.Use(db)
 
 	_, err = client.Connect(&config)
 	if err != nil {
-		return nil, fmt.Errorf("unable to connect to database: %w", err)
+		return nil, errorsource.DownstreamError(fmt.Errorf("unable to connect to database: %w", err), false)
 	}
 
 	return slo.NewMetricsWrapper(NewDatasourceInstance(client, &config), dsiConfig), nil


### PR DESCRIPTION
Hey all,
I was looking at datasource logs and these were marked as plugin errors and triggering warnings, but they probably shouldn't. I think this is cause NewDatasource is being called on each query call, and therefore returning a plugin error/500:

<img width="500" alt="Screenshot 2024-10-03 at 15 08 00" src="https://github.com/user-attachments/assets/a2f940b6-81ed-4df3-85ee-4c450a4c145b">

I tried fixing it by just wrapping it in errorsource.DownstreamError and I think it works (plus a more user friendly error)? 
<img width="461" alt="Screenshot 2024-10-03 at 15 07 29" src="https://github.com/user-attachments/assets/9f7ea56b-108d-474d-845a-c68790beec76">
