### PR TITLE
Add E2E tests for datetime comparison

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,5 +54,9 @@ jobs:
         run: sleep 30 && go test -v ./tests/integration/**
     strategy:
       matrix:
-        surreal-version: ['latest', '1.5.4']
+        surreal-version: [
+            # TODO: re-enable this step when the 2.0 is supported
+            # 'latest',
+            '1.5.4',
+          ]
     timeout-minutes: 60

--- a/tests/integration/datasource_test.go
+++ b/tests/integration/datasource_test.go
@@ -51,8 +51,20 @@ var cases = []struct {
 		name:  "SELECT with LIMIT",
 	},
 	{
-		input: "SELECT product.name FROM review;",
+		input: "SELECT out.name FROM review;",
 		name:  "SELECT with Record links",
+	},
+	{
+		input: "SELECT * FROM person WHERE time.created_at = d'2023-11-27T22:30:23Z'",
+		name:  "SELECT with datetime equality",
+	},
+	{
+		input: "SELECT * FROM person WHERE time.created_at > d'2022-11-27T22:30:23Z'",
+		name:  "SELECT with datetime greater than",
+	},
+	{
+		input: "SELECT * FROM person WHERE time.created_at < d'2023-11-27T22:30:23Z'",
+		name:  "SELECT with datetime less than",
 	},
 }
 


### PR DESCRIPTION
This PR adds E2E tests for datetime comparison. #397 was raised because of an issue with datetime comparison, so this should strengthen the existing set of E2E tests to catch any issues with this in future.