### PR TITLE
Add compatibility warning for SurrealDB v2.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,5 +71,9 @@ jobs:
           retention-days: 30
     strategy:
       matrix:
-        surreal-version: ['latest', '1.5.4']
+        surreal-version: [
+            # TODO: re-enable this step when the 2.0 is supported
+            # 'latest',
+            '1.5.4',
+          ]
     timeout-minutes: 60

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The SurrealDB datasource plugin enables you to query and visualize SurrealDB data directly within Grafana, offering seamless integration and exploration of SurrealDB datasets.
 
+## ⚠️ SurrealDB v2.0 compatibility
+
+**Important:** The Grafana SurrealDB datasource currently does not support SurrealDB v2.0. Please ensure you are using a compatible version of SurrealDB (v1.x) for full functionality. Follow the GitHub issue [here](https://github.com/grafana/surrealdb-datasource/issues/441) for updates on compatibility.
+
 ## ⚠️ This plugin is currently experimental
 
 This means that while we believe in its potential and are enthusiastic about its development, **we are not yet ready to make a long-term commitment to maintaining it indefinitely**. The plugin is still under active development and may contain bugs. We do not recommend using this plugin in production environments.

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent } from 'react';
-import { Alert, Divider, Field, Input, SecretInput, TextLink, VerticalGroup } from '@grafana/ui';
+import { Alert, Divider, Field, Input, SecretInput, Stack, TextLink } from '@grafana/ui';
 import { DataSourceDescription, ConfigSection } from '@grafana/experimental';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import type { SurrealDataSourceOptions, SurrealSecureJsonData } from '../types';
@@ -87,8 +87,21 @@ export function ConfigEditor({ onOptionsChange, options }: Props) {
         hasRequiredFields
       />
       <Divider />
+      <Alert title="SurrealDB v2.0 compatibility" severity="warning">
+        <Stack direction='column'>
+          <div>
+            The Grafana SurrealDB datasource currently does not support SurrealDB v2.0. Please ensure you are using a
+            compatible version of SurrealDB (v1.x) for full functionality. Follow the GitHub issue{' '}
+            <TextLink href="https://github.com/grafana/surrealdb-datasource/issues/441" external inline>
+              here
+            </TextLink>{' '}
+            for updates on compatibility.
+          </div>
+        </Stack>
+      </Alert>
+
       <Alert title="This datasource is currently experimental" severity="warning">
-        <VerticalGroup>
+        <Stack direction='column'>
           <div>
             This means that you might encounter unexpected behavior, bugs, or limitations while using this datasource.
             We strongly advise exercising caution and understanding the potential risks associated with using
@@ -101,8 +114,9 @@ export function ConfigEditor({ onOptionsChange, options }: Props) {
             </TextLink>
             !
           </div>
-        </VerticalGroup>
+        </Stack>
       </Alert>
+
       <ConfigSection title="Server">
         <Field
           required


### PR DESCRIPTION
As stated in #441 and #397, the datasource is not compatible with SurrealDB v2.0 at present due to the Go driver being incompatible at present. This PR warns about the incompatibility.