### PR TITLE
Prepare v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.5
+
+- Dependency updates.
+
 ## 0.2.4
 
 Released 27/12/2024.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,33 +6,23 @@
 
 ## 0.2.4
 
-Released 27/12/2024.
-
 - Dependency updates.
 
 ## 0.2.3
-
-Released 31/10/2024.
 
 - Add compatibility warning for SurrealDB v2.0.
 - Dependency updates.
 
 ## 0.2.2
 
-Released 16/10/2024.
-
 - Dependency updates.
 - Updates to error source capture.
 
 ## 0.2.1
 
-Released 09/09/2024.
-
 - Dependency updates.
 
 ## 0.2.0
-
-Released 08/08/2024.
 
 - Added support for Grafana macros.
 - Added `QueryWithContext` method to better handle context cancellation and timeouts.
@@ -43,19 +33,15 @@ Released 08/08/2024.
 
 ## 0.1.2
 
-Released 11/04/2024.
-
 - Fixed Alerting support not activated.
 - Go version update to 1.21.6.
 - Dependency updates.
 
 ## 0.1.1
 
-Released 01/02/2024.
-
 - Dependency updates.
 - Added `README.md` file to `src` directory for display on Grafana plugin page.
 
 ## 0.1.0
 
-Released 31/01/2024. Initial experimental release.
+Initial experimental release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb-datasource",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "SurrealDB datasource plugin for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Other plugins don't have release dates in change log. I think we should remove them. If we still want the dates, we should use the silly American format because our standard is American English 