### PR TITLE
Upgrade Go and prepare release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         environment: [dev, ops, prod]
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v5.1.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v6.1.1
     permissions:
       contents: write
       id-token: write
@@ -39,6 +39,4 @@ jobs:
       environment: ${{ matrix.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       scopes: ${{ github.event.inputs.environment == 'cloud (recommended)' && 'grafana_cloud' || github.event.inputs.environment == 'on-prem (for emergencies fix to On Prem customers)' && 'universal' }}
-      go-version: "1.26"
-      golangci-lint-version: "2.10.1"
       run-playwright: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,6 @@ jobs:
       environment: ${{ matrix.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       scopes: ${{ github.event.inputs.environment == 'cloud (recommended)' && 'grafana_cloud' || github.event.inputs.environment == 'on-prem (for emergencies fix to On Prem customers)' && 'universal' }}
-      go-version: "1.24"
-      golangci-lint-version: "2.1.6"
+      go-version: "1.26"
+      golangci-lint-version: "2.10.1"
       run-playwright: false

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,6 +17,6 @@ jobs:
       id-token: write
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
-      go-version: "1.24"
-      golangci-lint-version: "2.1.6"
+      go-version: "1.26"
+      golangci-lint-version: "2.10.1"
       run-playwright: false

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,12 +11,10 @@ permissions: {}
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v5.1.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v6.1.1
     permissions:
       contents: read
       id-token: write
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
-      go-version: "1.26"
-      golangci-lint-version: "2.10.1"
       run-playwright: false

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,6 +15,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      attestations: write
+      pull-requests: read
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       run-playwright: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
+## 0.2.9
+
+- Dependency updates.
+
 ## 0.2.8
 
 - Dependency updates.
-  
+
 ## 0.2.7
 
 - **Chore** no-change version bump to fix release pipeline

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana-labs/surrealdb-datasource
 
-go 1.24.6
+go 1.26.0
 
 require (
 	github.com/grafana/grafana-plugin-sdk-go v0.283.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb-datasource",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "SurrealDB datasource plugin for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Upgrading Go and its dependents.

Prepare release.

Part of https://github.com/grafana/data-sources/issues/1041